### PR TITLE
Rename class to TryResult

### DIFF
--- a/polyfill.d.ts
+++ b/polyfill.d.ts
@@ -5,63 +5,38 @@
 //
 // See https://github.com/microsoft/TypeScript/issues/42033
 
-/**
- * Error result type expressed as object
- */
-type ErrorObjectResult = { ok: false; error: unknown; value: undefined }
 
 /**
- * Error result type expressed as tuple.
- *
- * - `error` type depends on `useUnknownInCatchVariables` tsconfig option
+ * A try result can represent the result of either a failed or successful operation.
+ * 
+ * The result can be either destructured or accessed by index.
+ * 
+ * - `error` type should depend on `useUnknownInCatchVariables` tsconfig option
+ * 
  */
-type ErrorTupleResult = [ok: false, error: unknown, value: undefined]
+type TryResult<V> = TryResultInner<true, undefined, V> | TryResultInner<false, unknown, undefined>;
+type TryResultInner<O, E, V> = [O, E, V] & { ok: O, error: E, value: V }
 
-/**
- * An error result is a object that can be either destructured {@link ErrorObjectResult} or accessed by index {@link ErrorTupleResult}
- */
-type ErrorResult = ErrorObjectResult & ErrorTupleResult
-
-/**
- * Value result type expressed as object
- */
-type ValueObjectResult<V> = { ok: true; error: undefined; value: V }
-
-/**
- * Value result type expressed as tuple
- */
-type ValueTupleResult<V> = [ok: true, error: undefined, value: V]
-
-/**
- * A value result is a object that can be either destructured {@link ValueObjectResult} or accessed by index {@link ValueTupleResult}
- */
-type ValueResult<V> = ValueObjectResult<V> & ValueTupleResult<V>
-
-/**
- * A result is a object that can represent the result of either a failed or successful operation.
- */
-type Result<V> = ErrorResult | ValueResult<V>
-
-interface ResultConstructor {
+interface TryResultConstructor {
   /**
    * Creates a result from a tuple
    *
    * @example
    *
-   * new Result(true, undefined, 42)
-   * new Result(false, new Error('Something went wrong'))
+   * new TryResult(true, undefined, 42)
+   * new TryResult(false, new Error('Something went wrong'))
    */
-  new <V>(...args: ValueTupleResult<V> | ErrorTupleResult): Result<V>
+  new<V>(...args: [boolean, unknown, V | undefined]): TryResult<V>;
 
   /**
    * Creates a result for a successful operation
    */
-  ok<V>(value: V): Result<V>
+  ok<V>(value: V): TryResult<V>
 
   /**
    * Creates a result for a failed operation
    */
-  error<V>(error: unknown): Result<V>
+  error<V>(error: unknown): TryResult<V>
 }
 
-declare const Result: ResultConstructor
+declare const TryResult: TryResultConstructor

--- a/polyfill.js
+++ b/polyfill.js
@@ -1,7 +1,7 @@
 /// <reference path="./polyfill.d.ts" />
 
-/** @type {ResultConstructor} */
-class Result {
+/** @type {TryResultConstructor} */
+class TryResult {
   constructor(ok, error, value) {
     this.ok = ok
     this.error = error
@@ -15,10 +15,10 @@ class Result {
   }
 
   static ok(value) {
-    return new Result(true, undefined, value)
+    return new TryResult(true, undefined, value)
   }
 
   static error(error) {
-    return new Result(false, error, undefined)
+    return new TryResult(false, error, undefined)
   }
 }


### PR DESCRIPTION
This renames the `Result` class to `TryResult`.

It also simplifies `polyfill.d.ts` a bit. 

<!--
Thank you for your pull request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
