### PR TITLE
Fix link to EffectJS error management documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@ This proposal is in its early stages, and we welcome your input to help refine i
 
 - [This tweet from @LeaVerou](https://x.com/LeaVerou/status/1819381809773216099)
 - The frequent oversight of error handling in JavaScript code.
-- [Effect TS Error Management](https://effect.website/docs/guides/error-management)
+- [Effect TS Error Management](https://effect.website/docs/error-management/two-error-types/)
 - The [`tuple-it`](https://www.npmjs.com/package/tuple-it) npm package, which introduces a similar concept but modifies the `Promise` and `Function` prototypes—an approach that is less ideal.
 
 <br />


### PR DESCRIPTION
The link 404s because the sections don't have index pages themselves. Changed to the page of the error management section instead.

<!--
Thank you for your pull request! Please provide a brief description above and review the requirements below.

Bug fixes and new features should include tests.

By submitting this contribution, I certify that:

* (a) I created it entirely or have the right to submit it under the project's open source license.
* (b) If based on prior work, I have the right to submit it with modifications under the same or an allowed license.
* (c) If provided by someone else, they certified (a), (b), or (c), and I have not modified it.
* (d) I understand this contribution is public, and a record of it (including personal details I submit) may be maintained indefinitely and redistributed under the project's license.
-->
