### PR TITLE
update with a simpler spec

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -10,6 +10,8 @@ stage: 0
 contributors: Arthur Fiorette, Arlen Beiler
 </pre>
 
+<emu-biblio href="node_modules/@tc39/ecma262-biblio/biblio.json"></emu-biblio>
+
 <emu-intro id="sec-intro">
   <h1>Introduction</h1>
   <emu-note>
@@ -18,276 +20,117 @@ contributors: Arthur Fiorette, Arlen Beiler
   <p>This proposal introduces a `try` operator and `Result` class to JavaScript for improved error handling ergonomics. The `try` operator evaluates an expression within an implicit try-catch block and returns a `Result` instance containing either the successful value or the caught error.</p>
 </emu-intro>
 
-<emu-clause id="sec-result-objects">
-  <h1>Result Objects</h1>
+<emu-clause id="sec-assignment-operators">
+  <h1>Assignment Operators</h1>
+  <h2>Syntax</h2>
+  <emu-grammar type="definition">
+    AssignmentExpression[In, Yield, Await] :
+      TryExpression[?In, ?Yield, ?Await]
+    TryExpression[In, Yield, Await] :
+      `try` [no LineTerminator here] [lookahead != `{`] AssignmentExpression[?In, ?Yield, ?Await]
+  </emu-grammar>
 
-  <emu-clause id="sec-result-constructor">
-    <h1>The Result Constructor</h1>
-    <p>The Result constructor is the %Result% intrinsic object. When called as a constructor, it creates and initializes a new Result object.</p>
+  <emu-note>
+    <p>Placing the `try` operator in assignment expression allows it to protect an entire assignment expression.</p>
+  </emu-note>
 
-    <emu-clause id="sec-result">
-      <h1>Result ( _ok_, _error_, _value_ )</h1>
-      <p>When `Result` is called with arguments _ok_, _error_, and _value_, the following steps are taken:</p>
-      <emu-alg>
-        1. If NewTarget is *undefined*, throw a *TypeError* exception.
-        1. Let _result_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Result.prototype%"*, « [[ResultState]], [[ResultValue]], [[ResultError]] »).
-        1. Let _booleanOk_ be ToBoolean(_ok_).
-        1. Perform ! CreateDataPropertyOrThrow(_result_, *"ok"*, _booleanOk_).
-        1. If _booleanOk_ is *true*, then
-          1. Set _result_.[[ResultState]] to ~success~.
-          1. Set _result_.[[ResultValue]] to _value_.
-          1. Perform ! CreateDataPropertyOrThrow(_result_, *"value"*, _value_).
-        1. Else,
-          1. Set _result_.[[ResultState]] to ~failure~.
-          1. Set _result_.[[ResultError]] to _error_.
-          1. Perform ! CreateDataPropertyOrThrow(_result_, *"error"*, _error_).
-        1. Return _result_.
-      </emu-alg>
-    </emu-clause>
-  </emu-clause>
-
-  <emu-clause id="sec-properties-of-the-result-constructor">
-    <h1>Properties of the Result Constructor</h1>
-
-    <emu-clause id="sec-result.ok">
-      <h1>Result.ok ( _value_ )</h1>
-      <p>When the `Result.ok` method is called with argument _value_, the following steps are taken:</p>
-      <emu-alg>
-        1. Let _result_ be ? Construct(%Result%, « *true*, *undefined*, _value_ »).
-        1. Return _result_.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-result.error">
-      <h1>Result.error ( _error_ )</h1>
-      <p>When the `Result.error` method is called with argument _error_, the following steps are taken:</p>
-      <emu-alg>
-        1. Let _result_ be ? Construct(%Result%, « *false*, _error_, *undefined* »).
-        1. Return _result_.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-result.try">
-      <h1>Result.try ( _arg_, ..._args_ )</h1>
-      <p>When the `Result.try` method is called with argument _arg_ and optional arguments _args_, the following steps are taken:</p>
-      <emu-alg>
-        1. Let _completion_ be Completion(ResultTryImplementation(_arg_, _args_)).
-        1. If _completion_ is an abrupt completion, then
-          1. Return ! Call(%Result.error%, %Result%, « _completion_.[[Value]] »).
-        1. Return _completion_.[[Value]].
-      </emu-alg>
-
-      <emu-clause id="sec-result-try-implementation" type="abstract operation">
-        <h1>ResultTryImplementation ( _arg_, _args_ )</h1>
-        <dl class="header">
-        </dl>
-        <emu-alg>
-          1. Let _result_ be *undefined*.
-          1. If IsCallable(_arg_) is *true*, then
-            1. Let _callResult_ be Completion(Call(_arg_, *undefined*, _args_)).
-            1. If _callResult_ is an abrupt completion, then
-              1. Return ! Call(%Result.error%, %Result%, « _callResult_.[[Value]] »).
-            1. Set _result_ to _callResult_.[[Value]].
-          1. Else,
-            1. Set _result_ to _arg_.
-          1. If _result_ is an Object and IsPromise(_result_) is *true*, then
-            1. Let _fulfillmentHandler_ be a new Abstract Closure with parameters (_value_) that captures nothing and performs the following steps when called:
-              1. Return ! Call(%Result.ok%, %Result%, « _value_ »).
-            1. Let _rejectionHandler_ be a new Abstract Closure with parameters (_reason_) that captures nothing and performs the following steps when called:
-              1. Return ! Call(%Result.error%, %Result%, « _reason_ »).
-            1. Let _onFulfilled_ be CreateBuiltinFunction(_fulfillmentHandler_, 1, *""*, « »).
-            1. Let _onRejected_ be CreateBuiltinFunction(_rejectionHandler_, 1, *""*, « »).
-            1. Return PerformPromiseThen(_result_, _onFulfilled_, _onRejected_).
-          1. Return ! Call(%Result.ok%, %Result%, « _result_ »).
-        </emu-alg>
-      </emu-clause>
-    </emu-clause>
-
-    <emu-clause id="sec-result.prototype">
-      <h1>Result.prototype</h1>
-      <p>The initial value of `Result.prototype` is the Result prototype object.</p>
-      <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
-    </emu-clause>
-  </emu-clause>
-
-  <emu-clause id="sec-properties-of-the-result-prototype-object">
-    <h1>Properties of the Result Prototype Object</h1>
-    <p>The Result prototype object:</p>
-    <ul>
-      <li>is an ordinary object.</li>
-      <li>is not a Result instance and does not have [[ResultState]], [[ResultValue]], or [[ResultError]] internal slots.</li>
-      <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
-    </ul>
-
-    <emu-clause id="sec-result.prototype-@@iterator">
-      <h1>Result.prototype [ %Symbol.iterator% ] ( )</h1>
-      <p>When the %Symbol.iterator% method is called, the following steps are taken:</p>
-      <emu-alg>
-        1. Let _result_ be the *this* value.
-        1. Return ? CreateResultIterator(_result_).
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-result.prototype.constructor">
-      <h1>Result.prototype.constructor</h1>
-      <p>The initial value of `Result.prototype.constructor` is %Result%.</p>
-    </emu-clause>
-
-    <emu-clause id="sec-result.prototype-@@toStringTag">
-      <h1>Result.prototype [ %Symbol.toStringTag% ]</h1>
-      <p>The initial value of the %Symbol.toStringTag% property is the String value *"Result"*.</p>
-      <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
-    </emu-clause>
-  </emu-clause>
-
-  <emu-clause id="sec-result-iterator-objects">
-    <h1>Result Iterator Objects</h1>
-    <p>A Result Iterator is an object that represents a specific iteration over a Result instance. There is not a named constructor for Result Iterator objects.</p>
-
-    <emu-clause id="sec-createresultiterator" type="abstract operation">
-      <h1>
-        CreateResultIterator (
-          _result_: a Result object,
-        ): either a normal completion containing a Result Iterator or a throw completion
-      </h1>
-      <dl class="header">
-      </dl>
-      <emu-alg>
-        1. Perform ? RequireInternalSlot(_result_, [[ResultState]]).
-        1. Let _iterator_ be OrdinaryObjectCreate(%ResultIteratorPrototype%, « [[IteratedResult]], [[ResultIteratorNextIndex]] »).
-        1. Set _iterator_.[[IteratedResult]] to _result_.
-        1. Set _iterator_.[[ResultIteratorNextIndex]] to 0.
-        1. Return _iterator_.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-%resultiteratorprototype%-object">
-      <h1>The %ResultIteratorPrototype% Object</h1>
-      <p>The %ResultIteratorPrototype% object:</p>
-      <ul>
-        <li>has a [[Prototype]] internal slot whose value is %IteratorPrototype%.</li>
-        <li>is an ordinary object.</li>
-      </ul>
-
-      <emu-clause id="sec-%resultiteratorprototype%.next">
-        <h1>%ResultIteratorPrototype%.next ( )</h1>
-        <emu-alg>
-          1. Let _iterator_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_iterator_, [[IteratedResult]]).
-          1. Let _result_ be _iterator_.[[IteratedResult]].
-          1. Let _index_ be _iterator_.[[ResultIteratorNextIndex]].
-          1. If _index_ is 0, then
-            1. Set _iterator_.[[ResultIteratorNextIndex]] to 1.
-            1. Let _okValue_ be ? Get(_result_, *"ok"*).
-            1. Return CreateIteratorResultObject(_okValue_, *false*).
-          1. Else if _index_ is 1, then
-            1. Set _iterator_.[[ResultIteratorNextIndex]] to 2.
-            1. If ? HasProperty(_result_, *"error"*) is *true*, then
-              1. Let _errorValue_ be ? Get(_result_, *"error"*).
-              1. Return CreateIteratorResultObject(_errorValue_, *false*).
-            1. Else,
-              1. Return CreateIteratorResultObject(*undefined*, *false*).
-          1. Else if _index_ is 2, then
-            1. Set _iterator_.[[ResultIteratorNextIndex]] to 3.
-            1. If ? HasProperty(_result_, *"value"*) is *true*, then
-              1. Let _valueValue_ be ? Get(_result_, *"value"*).
-              1. Return CreateIteratorResultObject(_valueValue_, *false*).
-            1. Else,
-              1. Return CreateIteratorResultObject(*undefined*, *false*).
-          1. Else,
-            1. Return CreateIteratorResultObject(*undefined*, *true*).
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-%resultiteratorprototype%-@@toStringTag">
-        <h1>%ResultIteratorPrototype% [ %Symbol.toStringTag% ]</h1>
-        <p>The initial value of the %Symbol.toStringTag% property is the String value *"Result Iterator"*.</p>
-        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
-      </emu-clause>
-    </emu-clause>
-  </emu-clause>
-</emu-clause>
-
-<emu-clause id="sec-try-operator">
-  <h1>The Try Operator</h1>
-
-  <emu-clause id="sec-try-operator-runtime-semantics">
-    <h1>Runtime Semantics</h1>
-
-    <emu-clause id="sec-try-operator-static-semantics">
-      <h1>Static Semantics</h1>
-      <emu-grammar>
-        UnaryExpression[Yield, Await] :
-          `try` UnaryExpression[?Yield, ?Await]
-      </emu-grammar>
-    </emu-clause>
-
-    <emu-clause id="sec-try-operator-evaluation" type="sdo">
-      <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar>UnaryExpression : `try` UnaryExpression</emu-grammar>
-      <emu-alg>
-        1. Let _exprRef_ be Completion(Evaluation of |UnaryExpression|).
-        1. If _exprRef_ is an abrupt completion, then
-          1. Return ! Call(%Result.error%, %Result%, « _exprRef_.[[Value]] »).
-        1. Let _value_ be Completion(GetValue(_exprRef_)).
-        1. If _value_ is an abrupt completion, then
-          1. Return ! Call(%Result.error%, %Result%, « _value_.[[Value]] »).
-        1. Return ! Call(%Result.ok%, %Result%, « _value_.[[Value]] »).
-      </emu-alg>
-    </emu-clause>
-  </emu-clause>
-
-  <emu-clause id="sec-try-operator-await-interaction">
-    <h1>Interaction with Await</h1>
-    <p>When the try operator is used with await, it captures both synchronous exceptions and asynchronous rejections.</p>
-
-    <emu-grammar>UnaryExpression : `try` `await` UnaryExpression</emu-grammar>
+  <emu-clause id="sec-comma-operator-runtime-semantics-evaluation" type="sdo">
+    <h1>Runtime Semantics: Evaluation</h1>
+    <emu-grammar>TryExpression : `try` AssignmentExpression</emu-grammar>
     <emu-alg>
-      1. Let _exprRef_ be the result of evaluating |UnaryExpression|.
-      1. Let _value_ be ? GetValue(_exprRef_).
-      1. Let _promise_ be ? PromiseResolve(%Promise%, _value_).
-      1. Let _fulfillmentHandler_ be a new Abstract Closure with parameters (_value_) that captures nothing and performs the following steps when called:
-        1. Return ! Call(%Result.ok%, %Result%, « _value_ »).
-      1. Let _rejectionHandler_ be a new Abstract Closure with parameters (_reason_) that captures nothing and performs the following steps when called:
-        1. Return ! Call(%Result.error%, %Result%, « _reason_ »).
-      1. Let _promiseFulfill_ be CreateBuiltinFunction(_fulfillmentHandler_, 1, *""*, « »).
-      1. Let _promiseReject_ be CreateBuiltinFunction(_rejectionHandler_, 1, *""*, « »).
-      1. Return ? Await(PerformPromiseThen(_promise_, _promiseFulfill_, _promiseReject_)).
+      1. Let _A_ be Completion(Evaluation of |Expression|).
+      1. If _A_ is an abrupt completion, return ? TryExpressionResult(_A_).
+      1. Let _B_ be Completion(GetValue(_A_)).
+      1. Return ? TryExpressionResult(_B_).
+    </emu-alg>
+    <emu-note>
+      <p>GetValue must be called even though its value is not used because it may have observable side-effects.</p>
+    </emu-note>
+    <emu-note>
+      <p>This is identical to <emu-xref href="#sec-try-statement-runtime-semantics-evaluation">evaluation of a try statement</emu-xref>.</p>
+    </emu-note>
+  </emu-clause>
+
+  <emu-clause id="sec-try-expression-result" type="abstract operation">
+    <h1>
+      TryExpressionResult (
+        _result_: a Completion Record,
+      ): either a normal completion containing a Result or an abrupt completion
+    </h1>
+    <dl class="header">
+    </dl>
+    <emu-alg>
+      1. If _result_ is a normal completion, return Result.ok(_result_.[[VALUE]]).
+      1. If _result_ is a throw completion, return Result.error(_result_.[[VALUE]]).
+      1. Return ? _result_.
     </emu-alg>
   </emu-clause>
-</emu-clause>
-
-<emu-clause id="sec-syntax-directed-operations">
-  <h1>Syntax-Directed Operations</h1>
-
-  <emu-clause id="sec-isvalidsimpleassignmenttarget" type="sdo">
-    <h1>Static Semantics: IsValidSimpleAssignmentTarget</h1>
-    <emu-grammar>UnaryExpression : `try` UnaryExpression</emu-grammar>
-    <emu-alg>
-      1. Return *false*.
-    </emu-alg>
+  <emu-clause id="sec-try-expression-result-ok" type="abstract operation">
+    <h1>
+      Result.ok (
+        _value_: an ECMAScript language value,
+      ): a Result
+    </h1>
+    <dl class="header">
+      <dt>description</dt>
+      <dd>It is the abstract equivelant of calling `Result.ok(value)`</dd>
+    </dl>
+  </emu-clause>
+  <emu-clause id="sec-try-expression-result-error" type="abstract operation">
+    <h1>
+      Result.error (
+        _value_: an ECMAScript language value,
+      ): a Result
+    </h1>
+    <dl class="header">
+      <dt>description</dt>
+      <dd>It is the abstract equivelant of calling `Result.error(value)`</dd>
+    </dl>
   </emu-clause>
 </emu-clause>
 
-<emu-annex id="sec-grammar-summary">
-  <h1>Grammar Summary</h1>
-
-  <emu-annex id="sec-expressions">
-    <h1>Expressions</h1>
-
-    <emu-prodref name="UnaryExpression"></emu-prodref>
-    <emu-grammar>
-      UnaryExpression[Yield, Await] :
-        UpdateExpression[?Yield, ?Await]
-        `delete` UnaryExpression[?Yield, ?Await]
-        `void` UnaryExpression[?Yield, ?Await]
-        `typeof` UnaryExpression[?Yield, ?Await]
-        `+` UnaryExpression[?Yield, ?Await]
-        `-` UnaryExpression[?Yield, ?Await]
-        `~` UnaryExpression[?Yield, ?Await]
-        `!` UnaryExpression[?Yield, ?Await]
-        <ins>`try` UnaryExpression[?Yield, ?Await]</ins>
-        [+Await] AwaitExpression[?Yield]
-    </emu-grammar>
-  </emu-annex>
-</emu-annex>
+<emu-clause id="sec-result-constructor">
+  <h1>The Result Constructor</h1>
+<pre><code class="javascript">
+class Result {
+  constructor(ok, error, value) {
+    ok = Boolean(ok)
+    this.ok = ok
+    if (ok) {
+      this.value = value
+    } else {
+      this.error = error
+    }
+  }
+  *[Symbol.iterator]() {
+    yield this.ok
+    yield this.error
+    yield this.value
+  }
+  static ok(value) {
+    return new Result(true, undefined, value)
+  }
+  static error(error) {
+    return new Result(false, error, undefined)
+  }
+  /* a convenience method for user-land, not used by the try operator */
+  static try(arg, ...args) {
+    try {
+      let result;
+      if (/* IsCallable(arg) */typeof arg === "function") {
+        result = arg.call(undefined, args)
+      } else {
+        result = arg;
+      }
+      if (/* IsPromise (result) */result instanceof Promise) {
+        return result.then(Result.ok, Result.error)
+      } else {
+        return Result.ok(result);
+      }
+    } catch (e) {
+      return Result.error(e)
+    }
+  }
+}
+</code></pre>
+</emu-clause>


### PR DESCRIPTION
Update the spec.emu file with a simpler spec. This is equivalent to the previous spec, except the previous version used unary expression instead of assignment expression, which is incorrect.