### PR TITLE
Refine README framing around caller-side conversion and no-flattening

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ const [ok, fetchErr, res] = try fs.readFileSync("data.txt")
 
 This proposal addresses the ergonomic challenges of managing multiple, often nested, `try/catch` blocks necessary for handling operations that may fail at various points.
 
-The try block needlessly encloses the protected code in a block. This often prevents straightforward `const` assignment patterns and can reduce readability through additional nesting. The `catch (error) {}` branch is usually where control-flow divergence happens, while the successful path is often linear.
+The try block needlessly encloses the protected code in a block. This often prevents straightforward `const` assignment patterns and can reduce readability and static analysis through additional nesting. The `catch (error) {}` branch is usually where control-flow divergence happens, while the successful path often just assigns a variable.
 
 The solution is to add a `try <expression>` operator, a syntax similar to `await <expression>`, which catches any error that occurs when executing its expression and returns it as a value to the caller.
 
@@ -32,18 +32,17 @@ JavaScript has no existing equivalent for in-place exception-to-value conversion
 - [Status](#status)
 - [Authors](#authors)
 - [Try/Catch Is Not Enough](#trycatch-is-not-enough)
-- [Caller's Approach](#callers-approach)
-- [Result as a Return Type](#result-as-a-return-type)
+- [Caller vs Callee: Using Result as a Return Type](#caller-vs-callee-using-result-as-a-return-type)
+- [No Flattening](#no-flattening)
 - [Try Operator](#try-operator)
   - [Expressions are evaluated in a self-contained `try/catch` block](#expressions-are-evaluated-in-a-self-contained-trycatch-block)
-  - [Can be inlined.](#can-be-inlined)
+  - [Can be inlined](#can-be-inlined)
   - [Any valid expression can be used](#any-valid-expression-can-be-used)
     - [`await` is not a special case](#await-is-not-a-special-case)
   - [Statements are not expressions](#statements-are-not-expressions)
   - [Never throws](#never-throws)
   - [Parenthesis Required for Object Literals](#parenthesis-required-for-object-literals)
   - [Void Operations](#void-operations)
-  - [No Flattening](#no-flattening)
   - [Precedence and Parsing Notes](#precedence-and-parsing-notes)
   - [Sharp Edges and Hazards](#sharp-edges-and-hazards)
 - [Result Class](#result-class)
@@ -142,7 +141,9 @@ function getPostInfo(session, postSlug, cache, db) {
 }
 ```
 
-In this example, the `try` blocks primarily introduce additional nesting.
+In this example, the `try` blocks primarily introduce additional nesting and prevents the additional protection of a `const` declaration.
+
+It also tends to interfere with static analysis tools, forcing developers to look for alternate solutions.
 
 Instead, using the proposed `try` operator simplifies the function:
 
@@ -181,101 +182,86 @@ This approach often improves readability by cleanly separating the happy path fr
 
 Control flow remains linear, making it easier to follow, while only exception paths require explicit branching.
 
+And because the try operator returns a defined shape, static analysis tools can easily understand it.
+
 The result is a more structured, maintainable function where failures are handled concisely without unnecessary indentation.
 
 <br />
 
-## Caller's Approach
+## Caller vs Callee: Using Result as a Return Type
 
-JavaScript has evolved over decades, with countless libraries and codebases built on top of one another. Any new feature that does not consider compatibility with existing code risks negatively impacting its adoption, as refactoring functional, legacy code simply to accommodate a new feature is often an unjustifiable cost.
+This proposal starts from a simple fact: JavaScript already has a large ecosystem of `throw`-based APIs. The goal is not to replace exception propagation, but to make exception-to-value conversion cheap exactly where the caller wants it. That lets callers choose the boundary where errors stop unwinding and start being handled as values.
 
-With that in mind, improvements in error handling can be approached in two ways:
+JavaScript already follows a similar model for asynchronous code. Promise rejections propagate up the `await` stack until the caller chooses a boundary with `.catch()`. The `try` operator brings that same caller-controlled inline exception-to-value conversion to synchronous code.
 
-1. **At the caller's level**:
+This is especially the case in server-style request handling. If `db.connect()`, `db.select()`, or `normalize()` throws, the practical outcome may be to abort the request, log the failure, and show a generic error page. Similar patterns appear in parser and validation code, where unexpected failures often just bubble until a specific boundary chooses to intercept them.
 
-   ```js
-   try {
-     const value = work()
-   } catch (error) {
-     console.error(error)
-   }
-   ```
-
-2. **At the callee's level**:
-
-   ```js
-   function work() {
-     try {
-       // Performs some operation
-
-       return { ok: true, value }
-     } catch (error) {
-       return { ok: false, error }
-     }
-   }
-   ```
-
-Both approaches turn failures into values, but the second one requires each function to adopt and preserve a `Result`-shaped contract. Languages like Go and Rust started with that model. JavaScript mostly did not, so introducing it later has a different compatibility and adoption profile.
-
-This proposal therefore focuses on caller-side conversion. It keeps the familiar placement of `try/catch`, works with existing throw-based APIs, and avoids broad refactors across codebases and libraries.
-
-Ironically, **these are precisely the kinds of functions where improved error handling is most needed**.
-
-<br />
-
-## Result as a Return Type
-
-Returning `Result` is valid and often useful, especially when callers should acknowledge specific failures explicitly.
-
-This proposal is optimized for a different default: JavaScript already has a large ecosystem of `throw`-based APIs, so converting errors into values _on the caller side_ is often the cheaper migration path.
-
-Consider a call chain where `getUser()` calls `db.select()`, which calls `db.connect()`. If none return `Result`, the caller can simply write:
+Consider a call chain where `getUser()` calls `db.connect()` and then `db.select()`. If none return `Result`, the stack will simply unwind automatically to whatever point that the caller decides.
 
 ```js
-function getUser(id) {
-  const conn = db.connect()
-  const user = db.select(conn, id)
-  return normalize(user);
+function getUser(id, request, response) {
+  const result = try normalize(db.select(db.connect(), id));
+
+  if(!result.ok) 
+    return response.send(JSON.stringify(result.value)).end();
+  else 
+    throw new ServerError(result.error, request, response);
 }
 ```
 
-This single `try` captures any error thrown anywhere in the chain. Compare that to returning `Result` throughout the stack:
+Giving the caller control over exactly where the stack unwinds to is often more useful than returning a `Result` directly.
+
+Returning a `Result` can force callers to acknowledge errors in ways JSDoc cannot. That benefit is real. The cost is that developers end up checking and rethrowing failures that would otherwise bubble naturally. Forcing the caller to check a result only to rethrow it is rarely necessary.
+
+If our database returned `Result` for every operation, it might force our developer to do something like this:
 
 ```js
 // Every function must check and forward errors.
 
-function getUser(id) {
+function getUser(id, request, response) {
   const connResult = db.connect()
 
   if (!connResult.ok) {
-    throw connResult.error
+    throw new ServerError(connResult.error, request, response);
   }
 
   const userResult = db.select(connResult.value, id)
 
   if (!userResult.ok) {
-    throw userResult
+    throw new ServerError(userResult.error, request, response);
   }
 
-  return normalize(userResult.value);
+  const normResult = normalize(userResult.value);
+
+  if (!normResult.ok) {
+    throw new ServerError(normResult.error, request, response);
+  }
+
+  return response.send(JSON.stringify(normResult.value)).end();
 }
 ```
 
 This is reminiscent of Go's `if err != nil { return err }`, even though Go's tuples and JavaScript `Result` objects are not otherwise the same abstraction. Sometimes that repetition is acceptable. Sometimes it is just redundant plumbing around behavior that would otherwise happen automatically.
 
-Returning `Result` can force callers to acknowledge errors in ways JSDoc cannot. That benefit is real. The cost is that developers end up checking and rethrowing failures that would otherwise bubble naturally.
+Nothing prevents developers from returning a `Result`, but the `try` operator solves the biggest reason why JavaScript developers often want to return a `Result` instead of throwing: the wonky and egregious code pathing and static-analysis breaking that is currently required.
 
-This is especially visible in server-style request handling. If `db.connect()`, `db.select()`, or `normalize()` throws, the practical outcome may already be to abort the request, log the failure, and show a generic error page. It is also useful for parsing and validation. 
-
-Forcing the caller to check the result for errors to rethrow is just more code they have to write. If the caller wants to catch one error, they can add the `try` operator at that one point and handle it. 
-
-Giving the caller the option to decide where they want their stack to unwind to when an error happens is often more useful than returning a result directly. 
-
-The `try` operator is designed to coexist with `throw`, not replace it. Mixed patterns (`Result` return + `throw`) do exist in practice. This proposal treats those as boundaries that should remain explicit rather than be silently normalized by the operator (see [No Flattening](#no-flattening)).
+Returning a `Result` is still valid and useful when callers should acknowledge failures explicitly and the failure information itself is part of the API contract. That is more likely when failures carry structured, standardized data, such as the success or failure of a financial transaction or an HTTP request that successfully got a `404` response.
 
 For further discussion, see [GitHub Issue #92](https://github.com/arthurfiorette/proposal-try-operator/issues/92).
 
 <br />
+
+## No Flattening
+
+Wrapping a `Result`-returning function with `try` yields `Result<Result<T>>`, not a flattened `Result<T>`.
+
+This is intentional. The `try` operator is meant to convert exceptions into known, guaranteed values at the call site. 
+
+If the callee returns a `Result`, that result is considered a value, even if it's a `Result` with an error property, because it represents code that ran to completion and called `return Result.error()`. 
+
+Flattening it would blur the clean boundary between successful execution and failed execution that `try` has to maintain. You could still infer it by exploring the source code or reading documentation, but it would no longer be a simple guaranteed operator. 
+
+The caller can wrap the expression in a simple helper function to flatten it. 
 
 ## Try Operator
 
@@ -343,7 +329,7 @@ try {
 const result = _result
 ```
 
-### Can be inlined.
+### Can be inlined
 
 Similar to `void`, `typeof`, `yield`, and `new`:
 
@@ -427,7 +413,7 @@ For example:
 
 All these thrown values are captured and encapsulated in the returned `Result`.
 
-As with other JavaScript constructs, host-level fatal termination conditions are out of scope.
+As with the try block, syntax and other fatal errors are out of scope.
 
 ### Parenthesis Required for Object Literals
 
@@ -474,18 +460,6 @@ function work() {
 
 Ignoring a `Result` should be treated as an explicit choice. In critical code paths, prefer handling or rethrowing to avoid accidentally swallowing failures.
 
-### No Flattening
-
-Wrapping a `Result`-returning function with `try` yields `Result<Result<T>>`, not a flattened `Result<T>`.
-
-This is intentional. Functions that return `Result` and also throw or reject do exist in practice. The rationale is not that mixed channels are impossible or invalid. It is that the operator should not silently normalize them.
-
-The nested shape keeps the boundary visible. In some cases, that visibility means `try` is unnecessary because the callee already returns `Result`. In others, it highlights a contract mismatch: the callee communicates some failures as `Result`, but still has exceptional failures that cross the same boundary.
-
-If this becomes a pain point, future proposals could introduce `Result.flatten()` or `.unwrap()` methods. By contrast, automatic flattening would be difficult to remove later without compatibility risk.
-
-When nested `Result` appears repeatedly, it usually indicates a boundary worth revisiting. Prefer picking one primary error channel per boundary and normalizing explicitly when a mixed model is intentional.
-
 ### Precedence and Parsing Notes
 
 This proposal keeps `try` expression-oriented. At Stage 0, the core goal is to validate ergonomics and semantics before final grammar tuning, but the intended parsing model is straightforward:
@@ -502,7 +476,6 @@ As the proposal advances, this section will be replaced by fully normative gramm
 This operator is intentionally small and does not replace all error-handling patterns.
 
 - `try fetch()` is not the same as `try await fetch()`. Rejections are caught when awaited.
-- `try <expression>` is not a substitute for `try/finally` when cleanup must always run.
 - Ignoring a `Result` can hide failures if done carelessly.
 - Catching all throws at expression level may also catch programmer mistakes (for example `TypeError`) unless code distinguishes and rethrows.
 - For shared policies (global retries, framework boundaries, platform-level telemetry), handling may belong at a higher boundary.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ const [ok, fetchErr, res] = try fs.readFileSync("data.txt")
 
 This proposal addresses the ergonomic challenges of managing multiple, often nested, `try/catch` blocks necessary for handling operations that may fail at various points.
 
-The try block needlessly encloses the protected code in a block. This often prevents straightforward `const` assignment patterns and can reduce readability and static analysis through additional nesting. The `catch (error) {}` branch is usually where control-flow divergence happens, while the successful path often just assigns a variable.
+The try block needlessly encloses the protected code in a block. This often prevents straightforward `const` assignment patterns and can reduce readability and hinder static analysis through additional nesting. The `catch (error) {}` branch is usually where control-flow divergence happens, while the successful path often just assigns a variable.
 
 The solution is to add a `try <expression>` operator, a syntax similar to `await <expression>`, which catches any error that occurs when executing its expression and returns it as a value to the caller.
 
@@ -144,7 +144,6 @@ function getPostInfo(session, postSlug, cache, db) {
 
 In this example, the `try` blocks introduce additional nesting and prevent the protection a `const` declaration would provide.
 
-It also tends to interfere with static analysis tools, forcing developers to look for alternate solutions.
 
 Instead, using the proposed `try` operator simplifies the function:
 
@@ -291,7 +290,7 @@ function getUser(id, request, response) {
 
 This is obviously far more code to maintain, a lot of it repetitive and often redundent in these scenarios. 
 
-I'm sure there are times when returning a Result might make sense, but this proposal isn't about that. It's about the `try` operator, and the try operator just needs some way to encapsulate its three values. 
+There are times when returning a Result might make sense, but this proposal isn't about that. It's about the `try` operator, and the try operator just needs some way to encapsulate its three values. 
 
 Even here, the benefit of the try operator is that developers can pass the whole try expression to a helper function that converts the Result into their chosen error composition cascade. The callback that would previously have been required, which often makes static analysis more context dependant and difficult, is no longer necessary.
 

--- a/README.md
+++ b/README.md
@@ -293,9 +293,10 @@ This is obviously far more code to maintain, a lot of it repetitive and often re
 
 I'm sure there are times when returning a Result might make sense, but this proposal isn't about that. It's about the `try` operator, and the try operator just needs some way to encapsulate its three values. 
 
-Even here, the benefit of the try operator is that developers can pass the whole try expression to a helper function that converts the Result into their chosen error composition cascade. 
+Even here, the benefit of the try operator is that developers can pass the whole try expression to a helper function that converts the Result into their chosen error composition cascade. The callback that would previously have been required and often breaks static analysis is no longer necessary.
 
 ```ts
+// instead of toChainMatch(() => db.select(db.connect(), id))
 toChainMatch(try db.select(db.connect(), id))
   .chain(user => { if(!user) throw "NOT_FOUND"; })
   .chain(normalize)

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ This is obviously far more code to maintain, a lot of it repetitive and often re
 
 I'm sure there are times when returning a Result might make sense, but this proposal isn't about that. It's about the `try` operator, and the try operator just needs some way to encapsulate its three values. 
 
-Even here, the benefit of the try operator is that developers can pass the whole try expression to a helper function that converts the Result into their chosen error composition cascade. The callback that would previously have been required and often breaks static analysis is no longer necessary.
+Even here, the benefit of the try operator is that developers can pass the whole try expression to a helper function that converts the Result into their chosen error composition cascade. The callback that would previously have been required, which often makes static analysis more context dependant and difficult, is no longer necessary.
 
 ```ts
 // instead of toChainMatch(() => db.select(db.connect(), id))

--- a/README.md
+++ b/README.md
@@ -293,6 +293,18 @@ This is obviously far more code to maintain, a lot of it repetitive and often re
 
 I'm sure there are times when returning a Result might make sense, but this proposal isn't about that. It's about the `try` operator, and the try operator just needs some way to encapsulate its three values. 
 
+Even here, the benefit of the try operator is that developers can pass the whole try expression to a helper function that converts the Result into their chosen error composition cascade. 
+
+```ts
+toChainMatch(try db.select(db.connect(), id))
+  .chain(user => { if(!user) throw "NOT_FOUND"; })
+  .chain(normalize)
+  .match({
+    ok: (user) => response.send(JSON.stringify(user)).end(),
+    error: (err) => { throw new ServerError(err); }
+  });
+```
+
 <br />
 
 ## Try Operator

--- a/README.md
+++ b/README.md
@@ -233,9 +233,9 @@ A user can always flatten the result if they want, but there's no way for them t
 
 ## Caller vs Callee: Return Result Directly?
 
-This proposal starts from a simple fact: JavaScript already has a large ecosystem of `throw`-based APIs. The goal is not to replace exception propagation, but to make exception-to-value conversion cheap exactly where the caller wants it. That lets callers choose the boundary where errors stop unwinding and start being handled as values.
+JavaScript already has a large ecosystem of `throw`-based APIs. The goal of this proposal is to make exceptions easier to consume and handle, not change how often developers throw errors. 
 
-JavaScript already follows a similar model for asynchronous code. Promise rejections propagate up the `await` stack until the caller chooses a boundary with `.catch()`. The `try` operator brings that same caller-controlled inline exception-to-value conversion to synchronous code.
+JavaScript already has a similar model for async code. Promise rejections propagate up the `await` stack until the caller chooses a boundary with `.catch()`. The `try` operator brings that same caller-controlled inline exception-to-value conversion to synchronous code.
 
 This is especially the case in server-style request handling. If `db.connect()`, `db.select()`, or `normalize()` throws, the practical outcome may be to abort the request, log the failure, and show a generic error page. Similar patterns appear in parser and validation code, where unexpected failures often just bubble until a specific boundary chooses to intercept them.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ JavaScript has no existing equivalent for in-place exception-to-value conversion
 - [The rules of `try...catch` must be maintained](#the-rules-of-trycatch-must-be-maintained)
   - [The Need for an `ok` Value](#the-need-for-an-ok-value)
   - [No Flattening](#no-flattening)
-- [Caller vs Callee: Using Result as a Return Type](#caller-vs-callee-using-result-as-a-return-type)
+- [Caller vs Callee: Return Result Directly?](#caller-vs-callee-return-result-directly)
 - [Try Operator](#try-operator)
   - [Expressions are evaluated in a self-contained `try/catch` block](#expressions-are-evaluated-in-a-self-contained-trycatch-block)
   - [Can be inlined](#can-be-inlined)
@@ -191,21 +191,24 @@ The result is a more structured, maintainable function where failures are handle
 
 ## The rules of `try...catch` must be maintained
 
-An operator behaves like a function call with arguments and a return value. The `await` operator, for instance, takes a single argument (the expression it awaits) and "returns" the value a promise resolves to, or "throws" the value a promise rejects with. 
+The `try` block is pretty simple: 
 
-Here, the `try` operator also takes a single argument (the code it protects) and "returns" a `Result`.
+- `try {}` - This block completes if nothing throws.
+- `catch (e) {}` - This block is run if something throws.
+- `finally {}` - This runs regardless of whether anything throws. 
 
-> [!TIP]  
->
-> A shorthand notation for `Result` in this proposal is `Result(true, value)` and `Result(false, error)`, representing `[true, undefined, value]` and `[false, error, undefined]`, respectively.
+The `try` operator runs an expression and returns three values.
 
-The `try` operator never throws, and it catches anything the code in its expression throws during execution. Just like the `try {}` block, it does NOT catch syntax errors since those occur when the file is loaded.
-
-The `try` operator must always maintain equivelance to the `try...catch` block. 
-
-- `try {}` - when the try operator returns `[true, undefined, value]`.
-- `catch (e) {}` - when the try operator returns `[false, error, undefined]`.
-- `finally {}` - statements following the try operator. 
+- `success` -- whether the expression threw
+- `error` -- if the expression throws, the value that was thrown
+- `value` -- if the expression returns, the value that was returned
+- The `success` boolean allows the user to add a conditional branch for the corresponding `catch` code.
+  ```
+  if (!success) {
+    // catch code
+  }
+  ```
+- Since `try` itself never throws, `finally` is implicit. 
 
 <br />
 ### The Need for an `ok` Value
@@ -222,13 +225,13 @@ The most obvious solution is to add a boolean to the result.
 
 Nested Results are not flattened, whether its a value or error.
 
-This is intentional. For the `try` operator to have the same guarantees as `try...catch`, it must let the user determine whether an expression throws or completes. Flattening a Result would blur the clean boundary between successful execution and failed execution, meaning the user could not distinguish between _returning_ `Result(false)` and actually throwing an error, or between _throwing_ `Result(true)` and actually returning a value. 
+This is intentional. Flattening a Result would allow the expression to lie about whether or not it threw, simply by returning an error Result or throwing a value Result.
 
 A user can always flatten the result if they want, but there's no way for them to _unflatten_ it if they need to know the difference. 
 
 <br />
 
-## Caller vs Callee: Using Result as a Return Type
+## Caller vs Callee: Return Result Directly?
 
 This proposal starts from a simple fact: JavaScript already has a large ecosystem of `throw`-based APIs. The goal is not to replace exception propagation, but to make exception-to-value conversion cheap exactly where the caller wants it. That lets callers choose the boundary where errors stop unwinding and start being handled as values.
 
@@ -236,24 +239,28 @@ JavaScript already follows a similar model for asynchronous code. Promise reject
 
 This is especially the case in server-style request handling. If `db.connect()`, `db.select()`, or `normalize()` throws, the practical outcome may be to abort the request, log the failure, and show a generic error page. Similar patterns appear in parser and validation code, where unexpected failures often just bubble until a specific boundary chooses to intercept them.
 
-Consider a call chain where `getUser()` calls `db.connect()` and then `db.select()`. If none return `Result`, the stack will simply unwind automatically to whatever point that the caller decides.
+It usually doesn't make sense in the modern JavaScript ecosystem for a library to return a Result. Most code already throws when something goes wrong. The `try` operator makes it easier to handle code that throws. Returning a result makes this more difficult. 
+
+Consider a call chain where `getUser()` calls `db.connect()` and then `db.select()`. If errors are simply thrown, the stack will unwind automatically to whatever point the caller decides.
 
 ```js
 function getUser(id, request, response) {
   const result = try normalize(db.select(db.connect(), id));
 
-  if (!result.ok) {
-    throw new ServerError(result.error, request, response);
+  if (!result.ok && result.error instanceof DBError && result.error.code === "NOT_FOUND") {
+    // return a custom message to the user
+    return response.status(404).end();
+  } else if (!result.ok) {
+    throw new ServerError(result.error);
   } else {
     return response.send(JSON.stringify(result.value)).end();
   }
+}
 ```
 
-Giving the caller control over exactly where the stack unwinds to is often more useful than returning a `Result` directly.
+Giving the caller control (with the `try` operator) over exactly how far the stack unwinds is often more useful than returning a `Result` directly.
 
-Returning a `Result` can force callers to acknowledge errors in ways JSDoc cannot. That benefit is real. The cost is that developers end up checking and rethrowing failures that would otherwise bubble naturally. Forcing the caller to check a result only to rethrow it is rarely necessary.
-
-If our database returned `Result` for every operation, it might force our developer to do something like this:
+If our database returned `Result` for every operation:
 
 ```js
 // Every function must check and forward errors.
@@ -262,30 +269,29 @@ function getUser(id, request, response) {
   const connResult = db.connect()
 
   if (!connResult.ok) {
-    throw new ServerError(connResult.error, request, response);
+    throw new ServerError(connResult.error);
   }
 
   const userResult = db.select(connResult.value, id)
 
   if (!userResult.ok) {
-    throw new ServerError(userResult.error, request, response);
+    throw new ServerError(userResult.error);
   }
 
+  // and return it from our function because we might as well at this point
   const normResult = normalize(userResult.value);
 
   if (!normResult.ok) {
-    throw new ServerError(normResult.error, request, response);
+    throw new ServerError(normResult.error);
   }
 
   return response.send(JSON.stringify(normResult.value)).end();
 }
 ```
 
-This is reminiscent of Go's `if err != nil { return err }`, even though Go's tuples and JavaScript `Result` objects are not otherwise the same abstraction. Sometimes that repetition is acceptable. Sometimes it is just redundant plumbing around behavior that would otherwise happen automatically.
+This is obviously far more code to maintain, a lot of it repetitive and often redundent in these scenarios. 
 
-Nothing prevents developers from returning a `Result`, but the `try` operator solves the biggest reason why JavaScript developers often want to return a `Result` instead of throwing: the wonky and egregious code pathing and static-analysis breaking that is currently required.
-
-Returning a `Result` is still valid and useful when callers should acknowledge failures explicitly and the failure information itself is part of the API contract. That is more likely when failures carry structured, standardized data, such as the success or failure of a financial transaction or an HTTP request that successfully got a `404` response.
+I'm sure there are times when returning a Result might make sense, but this proposal isn't about that. It's about the `try` operator, and the try operator just needs some way to encapsulate its three values. 
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,10 @@ JavaScript has no existing equivalent for in-place exception-to-value conversion
 - [Status](#status)
 - [Authors](#authors)
 - [Try/Catch Is Not Enough](#trycatch-is-not-enough)
+- [The rules of `try...catch` must be maintained](#the-rules-of-trycatch-must-be-maintained)
+  - [The Need for an `ok` Value](#the-need-for-an-ok-value)
+  - [No Flattening](#no-flattening)
 - [Caller vs Callee: Using Result as a Return Type](#caller-vs-callee-using-result-as-a-return-type)
-- [No Flattening](#no-flattening)
 - [Try Operator](#try-operator)
   - [Expressions are evaluated in a self-contained `try/catch` block](#expressions-are-evaluated-in-a-self-contained-trycatch-block)
   - [Can be inlined](#can-be-inlined)
@@ -56,7 +58,6 @@ JavaScript has no existing equivalent for in-place exception-to-value conversion
   - [Type-Safe Errors](#type-safe-errors)
   - [Automatic Error Handling](#automatic-error-handling)
 - [Why Not `data` First?](#why-not-data-first)
-- [The Need for an `ok` Value](#the-need-for-an-ok-value)
 - [A Case for Syntax](#a-case-for-syntax)
 - [Why This Belongs in the Language](#why-this-belongs-in-the-language)
 - [Evidence Plan](#evidence-plan)
@@ -188,6 +189,41 @@ The result is a more structured, maintainable function where failures are handle
 
 <br />
 
+## The rules of `try...catch` must be maintained
+
+An operator behaves like a function call with arguments and a return value. The `await` operator, for instance, takes a single argument (the code it awaits) and "returns" the value a promise resolves to, or "throws" the value a promise rejects with. 
+
+Here, the `try` operator also takes a single argument, the code it protects, and "returns" a `Result`.
+
+A shorthand notation for `Result` in this proposal is `Result(true, value)` and `Result(false, error)`, representing `[true, undefined, value]` and `[false, error, undefined]`, respectively.
+
+The `try` operator never throws, and it catches anything the code in its expression throws during execution. Just like the `try {}` block, it does NOT catch syntax errors since those occur when the file is loaded.
+
+The `try` operator must always maintain equivelance to the `try...catch` block. 
+
+- `try {}` - when the try operator returns `[true, undefined, value]`.
+- `catch (e) {}` - when the try operator returns `[false, error, undefined]`.
+- `finally {}` - statements following the try operator. 
+
+
+### The Need for an `ok` Value
+
+In JavaScript, `throw x` throws `x`. There is no wrapping or any other processing, so `throw undefined` is perfectly valid.
+
+Because code can both throw `undefined` and return `undefined`, there is no way to tell whether it was successful based on `error` and `value` alone. No matter how undesirable it is to throw `undefined`, it is completely valid JavaScript. In order to maintain the guarantees of the `try...catch` block, there has to be some way to tell the difference between a thrown value and a returned value that still allows `undefined` to be a thrown value. 
+
+The most obvious solution is to add a boolean to the result. 
+
+### No Flattening
+
+Nested Results are not flattened, whether its a value or error.
+
+This is intentional. For the `try` operator to have the same guarantees as `try...catch`, it must let the user determine whether the expression threw or returned. Flattening a Result would blur the clean boundary between successful execution and failed execution. 
+
+If the user wants to flatten the result, that's fine, but there's no way for them to _unflatten_ it if they needed to know the difference. 
+
+<br />
+
 ## Caller vs Callee: Using Result as a Return Type
 
 This proposal starts from a simple fact: JavaScript already has a large ecosystem of `throw`-based APIs. The goal is not to replace exception propagation, but to make exception-to-value conversion cheap exactly where the caller wants it. That lets callers choose the boundary where errors stop unwinding and start being handled as values.
@@ -247,15 +283,7 @@ Nothing prevents developers from returning a `Result`, but the `try` operator so
 
 Returning a `Result` is still valid and useful when callers should acknowledge failures explicitly and the failure information itself is part of the API contract. That is more likely when failures carry structured, standardized data, such as the success or failure of a financial transaction or an HTTP request that successfully got a `404` response.
 
-For further discussion, see [GitHub Issue #92](https://github.com/arthurfiorette/proposal-try-operator/issues/92).
-
 <br />
-
-## No Flattening
-
-Wrapping a `Result`-returning function with `try` yields `Result<Result<T>>`, not a flattened `Result<T>`.
-
-This is intentional. The `try` operator must always maintain equivelance to the `try...catch` block. Flattening a Result would blur the clean boundary between successful execution and failed execution that a `try...catch` block guarantees. For the `try` operator to have the same guarantees, a returned value must always be separated from a thrown value.
 
 ## Try Operator
 
@@ -615,31 +643,6 @@ try {
 ```
 
 A detailed discussion about this topic is available at [GitHub Issue #13](https://github.com/arthurfiorette/proposal-try-operator/issues/13) for those interested.
-
-<br />
-
-## The Need for an `ok` Value
-
-In JavaScript, `throw x` throws `x`. There is no wrapping or any other processing, so `throw undefined` is perfectly valid.
-
-Consider the following pseudocode:
-
-```js
-function doWork(input) {
-  if(!db.saveUser(input))
-    throw undefined;
-}
-
-const [error, data] = try doWork(input)
-
-if (!error) {
-  user.send({success: true})
-}
-```
-
-Because `doWork` throws `undefined` and returns `undefined`, there is no way to tell whether it was successful. No matter how undesirable this contrived example is, it is completely valid JavaScript. In order to maintain the guarantees of the `try...catch` block, there has to be some way to tell the difference between a thrown value and a returned value that allows `undefined` to be a thrown value. 
-
-For a more in-depth explanation of this decision, refer to [GitHub Issue #30](https://github.com/arthurfiorette/proposal-try-operator/issues/30).
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -218,9 +218,9 @@ The most obvious solution is to add a boolean to the result.
 
 Nested Results are not flattened, whether its a value or error.
 
-This is intentional. For the `try` operator to have the same guarantees as `try...catch`, it must let the user determine whether the expression threw or returned. Flattening a Result would blur the clean boundary between successful execution and failed execution. 
+This is intentional. For the `try` operator to have the same guarantees as `try...catch`, it must let the user determine whether an expression throws or completes. Flattening a Result would blur the clean boundary between successful execution and failed execution, meaning the user could not distinguish between _returning_ `Result(false)` and actually throwing an error, or between _throwing_ `Result(true)` and actually returning a value. 
 
-If the user wants to flatten the result, that's fine, but there's no way for them to _unflatten_ it if they needed to know the difference. 
+A user can always flatten the result if they want, but there's no way for them to _unflatten_ it if they need to know the difference. 
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -255,13 +255,7 @@ For further discussion, see [GitHub Issue #92](https://github.com/arthurfiorette
 
 Wrapping a `Result`-returning function with `try` yields `Result<Result<T>>`, not a flattened `Result<T>`.
 
-This is intentional. The `try` operator is meant to convert exceptions into known, guaranteed values at the call site. 
-
-If the callee returns a `Result`, that result is considered a value, even if it's a `Result` with an error property, because it represents code that ran to completion and called `return Result.error()`. 
-
-Flattening it would blur the clean boundary between successful execution and failed execution that `try` has to maintain. You could still infer it by exploring the source code or reading documentation, but it would no longer be a simple guaranteed operator. 
-
-The caller can wrap the expression in a simple helper function to flatten it. 
+This is intentional. The `try` operator must always maintain equivelance to the `try...catch` block. Flattening a Result would blur the clean boundary between successful execution and failed execution that a `try...catch` block guarantees. For the `try` operator to have the same guarantees, a returned value must always be separated from a thrown value.
 
 ## Try Operator
 
@@ -626,29 +620,24 @@ A detailed discussion about this topic is available at [GitHub Issue #13](https:
 
 ## The Need for an `ok` Value
 
-The idea of `throw x` doing _anything_ other than throwing `x` is inherently flawed. Wrapping the `error` in an object disregards this principle and introduces unnecessary ambiguity.
+In JavaScript, `throw x` throws `x`. There is no wrapping or any other processing, so `throw undefined` is perfectly valid.
 
-Consider the following pseudocode, which might seem harmless but is actually risky:
+Consider the following pseudocode:
 
 ```js
-function doWork() {
-  if (check) {
-    throw createException(Errors.SOMETHING_WENT_WRONG)
-  }
-
-  return work()
+function doWork(input) {
+  if(!db.saveUser(input))
+    throw undefined;
 }
 
-const [error, data] = try doWork()
+const [error, data] = try doWork(input)
 
 if (!error) {
-  user.send(data)
+  user.send({success: true})
 }
 ```
 
-There is no guarantee that `createException` always returns an exception. Someone could even mistakenly write `throw null` or `throw undefined`, both of which are valid but undesired JavaScript code.
-
-Even though such cases are uncommon, they can occur. The `ok` value is crucial to mitigate these runtime risks effectively.
+Because `doWork` throws `undefined` and returns `undefined`, there is no way to tell whether it was successful. No matter how undesirable this contrived example is, it is completely valid JavaScript. In order to maintain the guarantees of the `try...catch` block, there has to be some way to tell the difference between a thrown value and a returned value that allows `undefined` to be a thrown value. 
 
 For a more in-depth explanation of this decision, refer to [GitHub Issue #30](https://github.com/arthurfiorette/proposal-try-operator/issues/30).
 
@@ -656,17 +645,15 @@ For a more in-depth explanation of this decision, refer to [GitHub Issue #30](ht
 
 ## A Case for Syntax
 
-This proposal intentionally combines the `try` operator with the `Result` class because each part motivates the other. The `try` operator standardizes a common pattern for safely catching synchronous function calls (similar to how Promise `.catch` handles async rejections).
+This proposal intentionally combines the `try` operator with the `Result` class because each part motivates the other. The `try` operator provides a useful pattern for safely catching synchronous function calls without resorting to block scope hoisting (similar to how Promise `.catch` handles async rejections by returning a user-defined value).
 
-At Stage 0, this is presented as a design hypothesis to validate with feedback and real-world usage:
+At Stage 0, this is presented as a design hypothesis to validate with feedback and real-world usage.
 
-- Syntax-only is incomplete: _it gives concise conversion but no shared standard outcome container_.
-- Runtime-only is incomplete: _it gives a container but keeps conversion boilerplate and callback wrappers_.
-- Combined proposal is coherent: _one expression form plus one standard shape_.
+It has been suggested that a runtime-only proposal for the `Result` class might face less resistance within the TC39 process. While this strategic viewpoint is understood, this proposal deliberately presents a unified feature. 
 
-It has been suggested that a runtime-only proposal for the `Result` class might face less resistance within the TC39 process. While this strategic viewpoint is understood, this proposal deliberately presents a unified feature. Separating the runtime from the syntax severs the solution from its motivating problem. It would ask the committee to standardize a `Result` object whose design is justified by a syntax **that doesn't yet exist**.
+Without the `try` operator, the `Result` class is just one of many possible library implementations, not a definitive language feature. Separating the runtime from the syntax severs the solution from its motivating problem. It would ask the committee to standardize a `Result` object whose design is justified by a syntax **that doesn't yet exist**.
 
-Without the `try` operator, the `Result` class is just one of many possible library implementations, not a definitive language feature. We believe the feature must be evaluated on its complete ergonomic and practical merits, which is only possible when the syntax and runtime are presented together.
+We believe the feature must be evaluated on its complete ergonomic and practical merits, which is only possible when the syntax and runtime are presented together.
 
 <br />
 
@@ -674,11 +661,9 @@ Without the `try` operator, the `Result` class is just one of many possible libr
 
 A proposal doesn’t need to introduce a feature that is entirely impossible to achieve otherwise. In fact, most recent proposals primarily reduce the complexity of tasks that are already achievable by providing built-in conveniences.
 
-The absence of a `Result`-like type and a standard pattern for safely wrapping function calls has led to ecosystem fragmentation. Multiple packages and private utilities attempt to fill this gap with different shapes and conventions. This leaves developers with a poor choice: risk adopting a library that may be abandoned, or contribute to the problem by creating yet another bespoke implementation.
+Like earlier ergonomics proposals such as optional chaining (`?.`) and nullish coalescing (`??`), this proposal targets a recurring pattern that appears repeatedly in userland. Unlike those features, it also introduces a standard error-outcome container. 
 
-Like earlier ergonomics proposals such as optional chaining (`?.`) and nullish coalescing (`??`), this proposal targets a recurring pattern that appears repeatedly in userland. Unlike those features, it also introduces a standard error-outcome container.
-
-It also creates a shared foundation between developers and package authors. Everyone can rely on the same Result implementation without compatibility concerns. The goal is to end the fragmentation and establish a foundational tool for robust error handling.
+At this stage of the proposal it is not intended to cover every variation of existing libraries out there, but simply to provide the features required for the `try` operator to work. 
 
 ## Evidence Plan
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ function getPostInfo(session, postSlug, cache, db) {
 }
 ```
 
-In this example, the `try` blocks primarily introduce additional nesting and prevents the additional protection of a `const` declaration.
+In this example, the `try` blocks introduce additional nesting and prevent the protection a `const` declaration would provide.
 
 It also tends to interfere with static analysis tools, forcing developers to look for alternate solutions.
 
@@ -202,11 +202,11 @@ Consider a call chain where `getUser()` calls `db.connect()` and then `db.select
 function getUser(id, request, response) {
   const result = try normalize(db.select(db.connect(), id));
 
-  if(!result.ok) 
-    return response.send(JSON.stringify(result.value)).end();
-  else 
+  if (!result.ok) {
     throw new ServerError(result.error, request, response);
-}
+  } else {
+    return response.send(JSON.stringify(result.value)).end();
+  }
 ```
 
 Giving the caller control over exactly where the stack unwinds to is often more useful than returning a `Result` directly.

--- a/README.md
+++ b/README.md
@@ -195,7 +195,9 @@ An operator behaves like a function call with arguments and a return value. The 
 
 Here, the `try` operator also takes a single argument (the code it protects) and "returns" a `Result`.
 
-A shorthand notation for `Result` in this proposal is `Result(true, value)` and `Result(false, error)`, representing `[true, undefined, value]` and `[false, error, undefined]`, respectively.
+> [!TIP]  
+>
+> A shorthand notation for `Result` in this proposal is `Result(true, value)` and `Result(false, error)`, representing `[true, undefined, value]` and `[false, error, undefined]`, respectively.
 
 The `try` operator never throws, and it catches anything the code in its expression throws during execution. Just like the `try {}` block, it does NOT catch syntax errors since those occur when the file is loaded.
 

--- a/README.md
+++ b/README.md
@@ -215,11 +215,9 @@ With that in mind, improvements in error handling can be approached in two ways:
    }
    ```
 
-Both approaches achieve the same goal, but the second one requires refactoring implementations into a new format. Languages like Go and Rust use callee-level result values from the start. Introducing that model later in JavaScript has a different compatibility and adoption profile.
+Both approaches turn failures into values, but the second one requires each function to adopt and preserve a `Result`-shaped contract. Languages like Go and Rust started with that model. JavaScript mostly did not, so introducing it later has a different compatibility and adoption profile.
 
-This proposal accounts for this by moving the transformation of errors into values to the **caller** level, preserving the familiar semantics and placement of `try/catch`. This approach ensures backward compatibility with existing code.
-
-For platforms like Node.js and widely used libraries, compatibility costs are high. As a result, a callee-based transition for APIs like `fetch` or `fs.readFile` is unlikely in practice because it would require broad refactoring across existing codebases.
+This proposal therefore focuses on caller-side conversion. It keeps the familiar placement of `try/catch`, works with existing throw-based APIs, and avoids broad refactors across codebases and libraries.
 
 Ironically, **these are precisely the kinds of functions where improved error handling is most needed**.
 
@@ -227,15 +225,21 @@ Ironically, **these are precisely the kinds of functions where improved error ha
 
 ## Result as a Return Type
 
-One of the `Result` principles is to wrap at the top, not throughout the stack. Returning `Result` from functions is possible, but often unnecessary.
+Returning `Result` is valid and often useful, especially when callers should acknowledge specific failures explicitly.
+
+This proposal is optimized for a different default: JavaScript already has a large ecosystem of `throw`-based APIs, so converting errors into values _on the caller side_ is often the cheaper migration path.
 
 Consider a call chain where `getUser()` calls `db.select()`, which calls `db.connect()`. If none return `Result`, the caller can simply write:
 
 ```js
-const result = try getUser(id)
+function getUser(id) {
+  const conn = db.connect()
+  const user = db.select(conn, id)
+  return normalize(user);
+}
 ```
 
-This single `try` captures any error thrown anywhere in the chain. Compare this to returning `Result` throughout the stack:
+This single `try` captures any error thrown anywhere in the chain. Compare that to returning `Result` throughout the stack:
 
 ```js
 // Every function must check and forward errors.
@@ -244,26 +248,30 @@ function getUser(id) {
   const connResult = db.connect()
 
   if (!connResult.ok) {
-    return connResult
+    throw connResult.error
   }
 
   const userResult = db.select(connResult.value, id)
 
   if (!userResult.ok) {
-    return userResult
+    throw userResult
   }
 
-  return Result.ok(normalize(userResult.value))
+  return normalize(userResult.value);
 }
 ```
 
-`Result`-returning functions cannot be freely composed with `throw`-based functions without explicit unwrapping at each boundary. This repetitive `if (!result.ok) { return result }` forwarding is reminiscent of Go's `if err != nil { return err }`. [Rob Pike's "Errors are values"](https://go.dev/blog/errors-are-values) addresses this: the solution is not more syntax sugar _(a `try?`-like operator)_, but recognizing that errors are values that can be programmed creatively. In many cases, this repetition is a useful signal that the code may benefit from restructuring rather than new syntax.
+This is reminiscent of Go's `if err != nil { return err }`, even though Go's tuples and JavaScript `Result` objects are not otherwise the same abstraction. Sometimes that repetition is acceptable. Sometimes it is just redundant plumbing around behavior that would otherwise happen automatically.
 
-Returning `Result` can force callers to acknowledge errors in ways JSDoc cannot. However, the function coloring tradeoff often outweighs this benefit. When acknowledgement is not required, a single `try` at the top of the call stack achieves the same safety without coloring every function in the chain.
+Returning `Result` can force callers to acknowledge errors in ways JSDoc cannot. That benefit is real. The cost is that developers end up checking and rethrowing failures that would otherwise bubble naturally.
 
-The `try` operator is designed to coexist with `throw`, not replace it. Following the [caller's approach](#callers-approach), functions typically throw and let callers decide how to handle errors. Returning `Result` can still make sense when forcing acknowledgement is more important than minimizing cross-boundary error-conversion boilerplate.
+This is especially visible in server-style request handling. If `db.connect()`, `db.select()`, or `normalize()` throws, the practical outcome may already be to abort the request, log the failure, and show a generic error page. It is also useful for parsing and validation. 
 
-Mixed patterns (`Result` return + `throw`) may exist in practice, but this proposal treats them as unusual boundaries rather than the default composition path (see [No Flattening](#no-flattening)).
+Forcing the caller to check the result for errors to rethrow is just more code they have to write. If the caller wants to catch one error, they can add the `try` operator at that one point and handle it. 
+
+Giving the caller the option to decide where they want their stack to unwind to when an error happens is often more useful than returning a result directly. 
+
+The `try` operator is designed to coexist with `throw`, not replace it. Mixed patterns (`Result` return + `throw`) do exist in practice. This proposal treats those as boundaries that should remain explicit rather than be silently normalized by the operator (see [No Flattening](#no-flattening)).
 
 For further discussion, see [GitHub Issue #92](https://github.com/arthurfiorette/proposal-try-operator/issues/92).
 
@@ -470,11 +478,13 @@ Ignoring a `Result` should be treated as an explicit choice. In critical code pa
 
 Wrapping a `Result`-returning function with `try` yields `Result<Result<T>>`, not a flattened `Result<T>`.
 
-This is intentional. Functions that return `Result` and also throw do exist in practice, but this proposal does not optimize for that pattern. The nested shape marks an unusual boundary: either `try` is unnecessary _(the callee already returns `Result`)_, or the callee contract is mismatched _(for example, it declares `Result<T>` but might throw)_. The rationale is not that `Result`-returning functions can never throw. It is that the operator should not silently normalize mixed channels.
+This is intentional. Functions that return `Result` and also throw or reject do exist in practice. The rationale is not that mixed channels are impossible or invalid. It is that the operator should not silently normalize them.
+
+The nested shape keeps the boundary visible. In some cases, that visibility means `try` is unnecessary because the callee already returns `Result`. In others, it highlights a contract mismatch: the callee communicates some failures as `Result`, but still has exceptional failures that cross the same boundary.
 
 If this becomes a pain point, future proposals could introduce `Result.flatten()` or `.unwrap()` methods. By contrast, automatic flattening would be difficult to remove later without compatibility risk.
 
-When nested `Result` appears repeatedly, it usually indicates a boundary mismatch. Prefer picking one error channel per boundary and normalizing explicitly.
+When nested `Result` appears repeatedly, it usually indicates a boundary worth revisiting. Prefer picking one primary error channel per boundary and normalizing explicitly when a mixed model is intentional.
 
 ### Precedence and Parsing Notes
 
@@ -705,6 +715,7 @@ Because this proposal is at **Stage 0**, proving the problem and tradeoffs has p
 - Compare before/after readability in terms of nesting depth and branching structure.
 - Classify where this operator prevents mistakes vs where it could hide mistakes if misused.
 - Catalog existing tuple/result wrappers and incompatibilities to justify standardization value.
+- Collect examples of mixed-channel code (`Result` return plus `throw`/rejection) to evaluate how common those boundaries are and where explicit normalization is preferable.
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ The result is a more structured, maintainable function where failures are handle
 
 An operator behaves like a function call with arguments and a return value. The `await` operator, for instance, takes a single argument (the code it awaits) and "returns" the value a promise resolves to, or "throws" the value a promise rejects with. 
 
-Here, the `try` operator also takes a single argument, the code it protects, and "returns" a `Result`.
+Here, the `try` operator also takes a single argument (the code it protects) and "returns" a `Result`.
 
 A shorthand notation for `Result` in this proposal is `Result(true, value)` and `Result(false, error)`, representing `[true, undefined, value]` and `[false, error, undefined]`, respectively.
 

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ The result is a more structured, maintainable function where failures are handle
 
 ## The rules of `try...catch` must be maintained
 
-An operator behaves like a function call with arguments and a return value. The `await` operator, for instance, takes a single argument (the code it awaits) and "returns" the value a promise resolves to, or "throws" the value a promise rejects with. 
+An operator behaves like a function call with arguments and a return value. The `await` operator, for instance, takes a single argument (the expression it awaits) and "returns" the value a promise resolves to, or "throws" the value a promise rejects with. 
 
 Here, the `try` operator also takes a single argument (the code it protects) and "returns" a `Result`.
 
@@ -207,7 +207,7 @@ The `try` operator must always maintain equivelance to the `try...catch` block.
 - `catch (e) {}` - when the try operator returns `[false, error, undefined]`.
 - `finally {}` - statements following the try operator. 
 
-
+<br />
 ### The Need for an `ok` Value
 
 In JavaScript, `throw x` throws `x`. There is no wrapping or any other processing, so `throw undefined` is perfectly valid.
@@ -215,6 +215,8 @@ In JavaScript, `throw x` throws `x`. There is no wrapping or any other processin
 Because code can both throw `undefined` and return `undefined`, there is no way to tell whether it was successful based on `error` and `value` alone. No matter how undesirable it is to throw `undefined`, it is completely valid JavaScript. In order to maintain the guarantees of the `try...catch` block, there has to be some way to tell the difference between a thrown value and a returned value that still allows `undefined` to be a thrown value. 
 
 The most obvious solution is to add a boolean to the result. 
+
+<br />
 
 ### No Flattening
 
@@ -669,6 +671,8 @@ A proposal doesn’t need to introduce a feature that is entirely impossible to 
 Like earlier ergonomics proposals such as optional chaining (`?.`) and nullish coalescing (`??`), this proposal targets a recurring pattern that appears repeatedly in userland. Unlike those features, it also introduces a standard error-outcome container. 
 
 At this stage of the proposal it is not intended to cover every variation of existing libraries out there, but simply to provide the features required for the `try` operator to work. 
+
+<br/>
 
 ## Evidence Plan
 


### PR DESCRIPTION
- Addresses #104 
- Addresses #103 

## Summary

This PR revises the README’s argument around `Result`-returning APIs and the `try` operator.

## What Changed

- Simplified a lot of Copilot gobbledygook. 
- Tried to clarify our position on APIs returning Result. 
- Tried to explain the benefit of the `try` operator more succinctly. 
- Tried to point out how this is already available in async code. 
- Tried to allow the idea of returning Result while also arguing against it so people don't start campaigning for it. 